### PR TITLE
Update to Cordova version 14 and changes to target Android API level 35

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -14,15 +14,24 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
+
+      - name: Set up Gradle 8.13
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          gradle-version: 8.13
 
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20.5.0
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2
+        
+      - name: Install Android SDK Build Tools 35.0.0
+        run: |
+          sdkmanager "build-tools;35.0.0" "platforms;android-35"
   
       - name: Import Android keystore and Google services JSON
         env:
@@ -37,7 +46,7 @@ jobs:
         run: npm install -g cordova
 
       - name: Add Cordova Android platform
-        run: cordova platform add android@12.0.0
+        run: cordova platform add android@14.0.0
 
       - name: Add cordova-plugin-androidx-adapter
         run: cordova plugin add cordova-plugin-androidx-adapter@1.1.3

--- a/config.xml
+++ b/config.xml
@@ -22,7 +22,9 @@
     <preference name="hostname" value="localhost" />
     <preference name="AndroidInsecureFileModeEnabled" value="true" />
     <preference name="AndroidPersistentFileLocation" value="Compatibility" />
-    <preference name="GradlePluginKotlinVersion" value="1.7.22"/>
+    <preference name="GradlePluginKotlinVersion" value="1.9.24"/>
+    <preference name="GradleVersion" value="8.13" />
+    <preference name="AndroidGradlePluginVersion" value="8.7.3" />
     <feature name="StatusBar">
         <param name="ios-package" onload="true" value="CDVStatusBar" />
     </feature>
@@ -33,7 +35,9 @@
         <resource-file src="res/xml/file_paths.xml" target="app/src/main/res/xml/file_paths.xml" />
         <resource-file src="res/icon.png" target="app/src/main/res/drawable/icon.png" />
         <preference name="android-minSdkVersion" value="24" />
-        <preference name="android-targetSdkVersion" value="34" />
+        <preference name="android-compileSdkVersion" value="35" />
+        <preference name="android-targetSdkVersion" value="35" />
+        <preference name="android-buildToolsVersion" value="35.0.0" />
         <preference name="AndroidXEnabled" value="true" />
         <preference name="SplashScreen" value="screen" />
         <preference name="AutoHideSplashScreen" value="true" />

--- a/cordova-plugin-inappbrowser-download/src/android/InAppBrowser.java
+++ b/cordova-plugin-inappbrowser-download/src/android/InAppBrowser.java
@@ -964,7 +964,15 @@ public class InAppBrowser extends CordovaPlugin {
                             }
                             if(photoFile != null) {
                                 mCM = "file:" + photoFile.getAbsolutePath();
-                                Uri uri = FileProvider.getUriForFile(cordova.getActivity().getApplicationContext(), cordova.getActivity().getPackageName() + ".provider", photoFile);
+                                Uri uri = null;
+                                try {
+                                    // FileProvider already defined by Cordova (.cdv.core.file.provider)
+                                    uri = FileProvider.getUriForFile(cordova.getContext(), cordova.getActivity().getPackageName() + ".cdv.core.file.provider", photoFile);
+                                    Log.d(LOG_TAG, "FileProvider URI created successfully ");
+                                } catch (Exception e) {
+                                    // TODO: handle exception
+                                    Log.d(LOG_TAG, "FileProvider failed",e);
+                                }
                                 takePictureIntent.putExtra(MediaStore.EXTRA_OUTPUT, uri);
                             } else {
                                 takePictureIntent = null;
@@ -1125,7 +1133,8 @@ public class InAppBrowser extends CordovaPlugin {
     private File createImageFile() throws IOException {
         @SuppressLint("SimpleDateFormat") String timeStamp = new SimpleDateFormat("yyyyMMdd_HHmmss").format(new Date());
         String imageFileName = "img_"+timeStamp+"_";
-        File storageDir = cordova.getActivity().getApplicationContext().getExternalFilesDir(null);
+        // use cache dir, follow with how cordova store image
+        File storageDir = cordova.getActivity().getCacheDir();
         return File.createTempFile(imageFileName,".jpg",storageDir);
     }
 

--- a/cordova-plugin-inappbrowser-download/src/android/InAppBrowserDownloads.java
+++ b/cordova-plugin-inappbrowser-download/src/android/InAppBrowserDownloads.java
@@ -193,7 +193,7 @@ public class InAppBrowserDownloads implements DownloadListener {
                 if (ContentResolver.SCHEME_FILE.equals(attachmentUri.getScheme())) {
                     // FileUri - Convert it to contentUri.
                     File file = new File(attachmentUri.getPath());
-                    attachmentUri = FileProvider.getUriForFile(context, plugin.cordova.getActivity().getPackageName() + ".provider", file);
+                    attachmentUri = FileProvider.getUriForFile(context, plugin.cordova.getActivity().getPackageName() + ".cdv.core.file.provider", file);
                 }
 
                 Intent openAttachmentIntent = new Intent(Intent.ACTION_VIEW);


### PR DESCRIPTION
Update Cordova Android to version 14.0.0 in order to support Android API level 35 (Android 15).

Key updates include:

- Updated build workflow (build-android.yml) and Cordova app configuration (config.xml) to meet Cordova Android 14 requirements (Java 17, Node.js ≥20.5, Gradle 8.13, Kotlin 1.9.24, Android SDK 35).

- Updated Cordova Android dependency from 12.0.0 to 14.0.0.

- Installed Android SDK Build Tools 35.0.0 and Platform 35 in the CI workflow.

- Use activity context instead of application context.

- Updated file storage implementation to use getCacheDir() instead of getExternalFilesDir() for image storage, aligning with Cordova implementation.