### PR TITLE
Fixed: Image upload not auto opened when downloaded.

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -25,6 +25,7 @@
     <preference name="GradlePluginKotlinVersion" value="1.9.24"/>
     <preference name="GradleVersion" value="8.13" />
     <preference name="AndroidGradlePluginVersion" value="8.7.3" />
+    <hook type="after_prepare" src="hooks/after_prepare/extend_file_provider.js" />
     <feature name="StatusBar">
         <param name="ios-package" onload="true" value="CDVStatusBar" />
     </feature>

--- a/hooks/after_prepare/extend_file_provider.js
+++ b/hooks/after_prepare/extend_file_provider.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+module.exports = function (ctx) {
+  // Cordova has added file provider path: https://github.com/apache/cordova-android/commit/b773ae48f44a8610366c81bda509d821a6d949ef
+  // The path only has cache path.
+  // Uses cordova hooks to include another paths.
+  
+  const filePath = path.join(
+    ctx.opts.projectRoot,
+    'platforms/android/app/src/main/res/xml/cdv_core_file_provider_paths.xml'
+  );
+
+  if (!fs.existsSync(filePath)) {
+    console.warn('[Hook] File not found:', filePath);
+    return;
+  }
+
+  let xml = fs.readFileSync(filePath, 'utf8');
+
+  const hasCachePath = xml.includes('<cache-path');
+  const hasExternalPath = xml.includes('<external-path');
+
+  if (!hasCachePath || !hasExternalPath) {
+    let injection = '';
+
+    //add cache & external-path in cdv_core_file_provider_paths.xml
+    if (!hasCachePath) {
+      injection += `\n    <cache-path name="cache" path="." />`;
+    }
+
+    if (!hasExternalPath) {
+      injection += `\n    <external-path name="external_files" path="." />`;
+    }
+
+    xml = xml.replace('</paths>', `${injection}\n</paths>`);
+
+    fs.writeFileSync(filePath, xml, 'utf8');
+
+    console.log('\x1b[32m%s\x1b[0m', '[Hook] Injected cache and external paths into cdv_core_file_provider_paths.xml');
+  } else {
+    console.log('\x1b[33m%s\x1b[0m', '[Hook] cache-path and external-path already exist, skipping injection.');
+  }
+};


### PR DESCRIPTION
The issue was caused because the downloaded file used an external storage path (/storage/emulated/0/...), while the `cdv_core_file_provider_paths.xml` configuration only defined a `<cache-path>`.

This mismatch caused a `java.lang.IllegalArgumentException` ("Failed to find configured root") when FileProvider attempted to generate a content URI.

- Fix: Added a Cordova hook to include an <external-path> entry in `cdv_core_file_provider_paths.xml`.