### PR TITLE
Override camera capture behaviour based on the form file input elemen…

### DIFF
--- a/cordova-plugin-inappbrowser-download/src/android/InAppBrowser.java
+++ b/cordova-plugin-inappbrowser-download/src/android/InAppBrowser.java
@@ -162,7 +162,10 @@ public class InAppBrowser extends CordovaPlugin {
     private boolean fullscreen = true;
     private String[] allowedSchemes;
     private InAppBrowserClient currentClient;
-    private String mCM;
+    // Used for <input type="file"> camera/video capture fallback when
+    // the returning intent doesn't include a data Uri (common with EXTRA_OUTPUT).
+    private String mCameraPhotoPath;
+    private String mCameraVideoPath;
     private PermissionRequest permissionRequest;
     private static final int CAMERA_REQ_CODE = 124;
 
@@ -951,24 +954,57 @@ public class InAppBrowser extends CordovaPlugin {
                         }
                         mUploadCallback = filePathCallback;
 
-                        Intent takePictureIntent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
+                        // Reset previous capture paths.
+                        mCameraPhotoPath = null;
+                        mCameraVideoPath = null;
 
-                        if(takePictureIntent.resolveActivity(cordova.getActivity().getPackageManager()) != null) {
+                        // Respect <input accept="..."> when provided.
+                        // If accept types are empty/unspecified, default to allowing images.
+                        boolean wantsImage = true;
+                        boolean wantsVideo = true;
+                        if (fileChooserParams != null) {
+                            String[] acceptTypes = fileChooserParams.getAcceptTypes();
+                            Log.d(LOG_TAG, "acceptTypes :>> " + acceptTypes);
+                            if (acceptTypes != null && acceptTypes.length > 0) {
+                                boolean sawNonEmpty = false;
+                                boolean image = false;
+                                boolean video = false;
+                                for (String t : acceptTypes) {
+                                    Log.d(LOG_TAG, "t :>> " + t);
+                                    if (t == null) continue;
+                                    t = t.trim();
+                                    if (t.isEmpty()) continue;
+                                    sawNonEmpty = true;
+                                    if ("*/*".equals(t)) { image = true; video = true; }
+                                    if (t.startsWith("image/")) image = true;
+                                    if (t.startsWith("video/")) video = true;
+                                }
+                                if (sawNonEmpty) {
+                                    wantsImage = image;
+                                    wantsVideo = video;
+                                }
+                                Log.d(LOG_TAG, "wantsImage :>> " +  wantsImage);
+                                Log.d(LOG_TAG, "wantsVideo :>> " + wantsVideo);
+                            }
+                        }
+
+                        Intent takePictureIntent = wantsImage ? new Intent(MediaStore.ACTION_IMAGE_CAPTURE) : null;
+
+                        if(takePictureIntent != null && takePictureIntent.resolveActivity(cordova.getActivity().getPackageManager()) != null) {
 
                             File photoFile = null;
                             try {
                                 photoFile = createImageFile();
-                                takePictureIntent.putExtra("PhotoPath", mCM);
                             } catch(IOException ex) {
                                 Log.e(LOG_TAG, "Image file creation failed", ex);
                             }
                             if(photoFile != null) {
-                                mCM = "file:" + photoFile.getAbsolutePath();
+                                mCameraPhotoPath = "file:" + photoFile.getAbsolutePath();
                                 Uri uri = null;
                                 try {
                                     // FileProvider already defined by Cordova (.cdv.core.file.provider)
                                     uri = FileProvider.getUriForFile(cordova.getContext(), cordova.getActivity().getPackageName() + ".cdv.core.file.provider", photoFile);
-                                    Log.d(LOG_TAG, "FileProvider URI created successfully ");
+                                    Log.d(LOG_TAG, "FileProvider photo URI created successfully ");
                                 } catch (Exception e) {
                                     // TODO: handle exception
                                     Log.d(LOG_TAG, "FileProvider failed",e);
@@ -978,16 +1014,46 @@ public class InAppBrowser extends CordovaPlugin {
                                 takePictureIntent = null;
                             }
                         }
+                        
+                        Intent videoIntent = wantsVideo ? new Intent(android.provider.MediaStore.ACTION_VIDEO_CAPTURE) : null;
+                        File videoFile = null;
+                        if(videoIntent != null && videoIntent.resolveActivity(cordova.getActivity().getPackageManager()) != null) {
+                            try {
+                                videoFile = createVideoFile();
+                            } catch(IOException ex) {
+                                Log.e(LOG_TAG, "Video file creation failed", ex);
+                            }
+                        }
+                        if(videoFile != null) {
+                            mCameraVideoPath = "file:" + videoFile.getAbsolutePath();
+                            Uri uri = null;
+                            try {
+                                uri = FileProvider.getUriForFile(cordova.getContext(), cordova.getActivity().getPackageName() + ".cdv.core.file.provider", videoFile);
+                                Log.d(LOG_TAG, "FileProvider video URI created successfully ");
+                            } catch (Exception e) {
+                                // TODO: handle exception
+                                Log.d(LOG_TAG, "FileProvider failed",e);
+                            }
+                            videoIntent.putExtra(MediaStore.EXTRA_OUTPUT, uri);
+                        } else {
+                            videoIntent = null;
+                        }
+
                         // Create File Chooser Intent
                         Intent contentSelectionIntent = new Intent(Intent.ACTION_GET_CONTENT);
                         contentSelectionIntent.addCategory(Intent.CATEGORY_OPENABLE);
-                        contentSelectionIntent.setType("*/*");
-                        Intent[] intentArray;
-                        if (takePictureIntent != null) {
-                            intentArray = new Intent[] { takePictureIntent };
+                        if (wantsImage && !wantsVideo) {
+                            contentSelectionIntent.setType("image/*");
+                        } else if (wantsVideo && !wantsImage) {
+                            contentSelectionIntent.setType("video/*");
                         } else {
-                            intentArray = new Intent[0];
+                            contentSelectionIntent.setType("*/*");
                         }
+
+                        ArrayList<Intent> extraIntents = new ArrayList<Intent>();
+                        if (videoIntent != null) extraIntents.add(videoIntent);
+                        if (takePictureIntent != null) extraIntents.add(takePictureIntent);
+                        Intent[] intentArray = extraIntents.toArray(new Intent[0]);
 
                         Intent chooserIntent = new Intent(Intent.ACTION_CHOOSER);
                         chooserIntent.putExtra(Intent.EXTRA_INTENT, contentSelectionIntent);
@@ -1138,6 +1204,14 @@ public class InAppBrowser extends CordovaPlugin {
         return File.createTempFile(imageFileName,".jpg",storageDir);
     }
 
+    private File createVideoFile() throws IOException {
+        @SuppressLint("SimpleDateFormat") String timeStamp = new SimpleDateFormat("yyyyMMdd_HHmmss").format(new Date());
+        String videoFileName = "vid_"+timeStamp+"_";
+        // use cache dir, follow with how cordova store video
+        File storageDir = cordova.getActivity().getCacheDir();
+        return File.createTempFile(videoFileName,".mp4",storageDir);
+    }
+
     // CUSTOM: File download support & camera grant resources onRequestPermissionsResult
     public void onRequestPermissionResult(int requestCode, String[] permissions, int[] grantResults) throws JSONException {
         if (InAppBrowser.this.downloads != null && permissionRequest == null) {
@@ -1215,8 +1289,30 @@ public class InAppBrowser extends CordovaPlugin {
                     }
                     if(intent == null || intent.getData() == null){
                         //Capture Photo if no image available
-                        if(mCM != null){
-                            results = new Uri[]{Uri.parse(mCM)};
+                        String fallback = null;
+                        // Prefer photo if it exists; otherwise fall back to video.
+                        if (mCameraPhotoPath != null) {
+                            try {
+                                File f = new File(Uri.parse(mCameraPhotoPath).getPath());
+                                if (f.exists() && f.length() > 0) {
+                                    fallback = mCameraPhotoPath;
+                                }
+                            } catch (Exception ignore) { }
+                        }
+                        if (fallback == null && mCameraVideoPath != null) {
+                            try {
+                                File f = new File(Uri.parse(mCameraVideoPath).getPath());
+                                if (f.exists() && f.length() > 0) {
+                                    fallback = mCameraVideoPath;
+                                }
+                            } catch (Exception ignore) { }
+                        }
+                        if (fallback == null) {
+                            // Last resort: return whichever was set (better than null for some camera apps)
+                            fallback = (mCameraPhotoPath != null) ? mCameraPhotoPath : mCameraVideoPath;
+                        }
+                        if (fallback != null) {
+                            results = new Uri[]{Uri.parse(fallback)};
                         }
                     }else{
                         String dataString = intent.getDataString();


### PR DESCRIPTION
Enabled video recording support for the file input element.

The app drawer now prompts users to capture media based on the configured file types. For example, specifying .jpg or .png on the joget form file input , it will trigger an image capture prompt, while specifying .mp4 will prompt for video recording.

Please let me know if any additional information is required.

<img width="1747" height="1884" alt="image" src="https://github.com/user-attachments/assets/63fda33e-07d9-4e18-983c-fc3758443a89" />
